### PR TITLE
User validation with email uc

### DIFF
--- a/src/__tests__/userController.test.ts
+++ b/src/__tests__/userController.test.ts
@@ -5,7 +5,7 @@ import { prismaMock } from '../singleton';
 test('should create a new user', async () => {
   const user = {
     body: {
-      email: 'test@example.com',
+      email: 'test@uc.cl',
       name: 'Test User',
       auth0Id: 'auth0|123',
       type: 'estudiante',
@@ -21,7 +21,7 @@ test('should create a new user', async () => {
   prismaMock.user.create.mockResolvedValue({
     id: 1,
     name: 'Test User',
-    email: 'test@example.com',
+    email: 'test@uc.cl',
     auth0Id: 'auth0|123',
     type: 'estudiante',
     createdAt: new Date(),
@@ -34,7 +34,7 @@ test('should create a new user', async () => {
     user: {
       id: 1,
       name: 'Test User',
-      email: 'test@example.com',
+      email: 'test@uc.cl',
       auth0Id: 'auth0|123',
       type: 'estudiante',
       createdAt: expect.any(Date),
@@ -45,7 +45,7 @@ test('should create a new user', async () => {
 test('should return error if user exists', async () => {
   const user = {
     body: {
-      email: 'test@example.com',
+      email: 'test@uc.cl',
       name: 'Test User',
       auth0Id: 'auth0|123',
       type: 'estudiante',
@@ -60,7 +60,7 @@ test('should return error if user exists', async () => {
   prismaMock.user.findUnique.mockResolvedValue({
     id: 1,
     name: 'Test User',
-    email: 'test@example.com',
+    email: 'test@uc.cl',
     auth0Id: 'auth0|123',
     type: 'estudiante',
   });
@@ -73,11 +73,34 @@ test('should return error if user exists', async () => {
   });
 });
 
+test('should return error if email is not from uc.cl', async () => {
+  const user = {
+    body: {
+      email: 'test@example.com',
+      name: 'Test User',
+      auth0Id: 'auth0|123',
+      type: 'estudiante',
+    },
+  } as Request;
+
+  const mockResponse = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as unknown as Response;
+
+  await createUser(user, mockResponse);
+
+  expect(mockResponse.status).toHaveBeenCalledWith(400);
+  expect(mockResponse.json).toHaveBeenCalledWith({
+    message: 'Invalid email',
+  });
+});
+
 test('should update user', async () => {
   const user = {
     body: {
       auth0Id: 'auth0|123',
-      email: 'test@example.com',
+      email: 'test@uc.cl',
       name: 'Test User',
       type: 'estudiante',
     },
@@ -91,7 +114,7 @@ test('should update user', async () => {
   prismaMock.user.findUnique.mockResolvedValue({
     id: 1,
     name: 'Test User',
-    email: 'test@example.com',
+    email: 'test@uc.cl',
     auth0Id: 'auth0|123',
     type: 'estudiante',
   });
@@ -99,7 +122,7 @@ test('should update user', async () => {
   prismaMock.user.update.mockResolvedValue({
     id: 1,
     name: 'Test User',
-    email: 'test@example.com',
+    email: 'test@uc.cl',
     auth0Id: 'auth0|123',
     type: 'estudiante',
   });
@@ -111,7 +134,7 @@ test('should update user', async () => {
     user: {
       id: 1,
       name: 'Test User',
-      email: 'test@example.com',
+      email: 'test@uc.cl',
       auth0Id: 'auth0|123',
       type: 'estudiante',
     },
@@ -122,7 +145,7 @@ test('should return error if user to update does not exist', async () => {
   const user = {
     body: {
       auth0Id: 'auth0|123',
-      email: 'test@example.com',
+      email: 'test@uc.cl',
       name: 'Test User',
       type: 'estudiante',
     },

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -13,6 +13,10 @@ export const createUser = async (req: Request, res: Response) => {
     if (existingUser) {
       return res.status(400).json({ message: 'User already exists' });
     }
+    
+    if (!email.endsWith('@uc.cl')) {
+      return res.status(400).json({ message: 'Invalid email' });
+    }
 
     const user = await prisma.user.create({
       data: {


### PR DESCRIPTION
## 📌 Descripción

Asegurar que solamente se pueda ingresar con correo @uc.cl
## ✅ Cambios realizados

- [ ] Modificar endpoint para la creacion de usuarios
- [ ] Agregado test para asegurar que no se creen usuarios sin el correo correcto

## 🧪 Cómo probar los cambios

N/A
