### PR TITLE
Feat/search filters

### DIFF
--- a/src/controllers/housingController.ts
+++ b/src/controllers/housingController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import prisma from '../prisma';
+import housingService from '../services/housingService';
 
 export const createHousing = async (req: Request, res: Response) => {
   try {
@@ -134,25 +135,17 @@ export const deleteHousing = async (req: Request, res: Response) => {
 
 export const listHousing = async (req: Request, res: Response) => {
   try {
-    const { available } = req.query;
+    const filters = {
+      available: req.query.available === 'true',
+      minPrice: req.query.minPrice ? parseFloat(req.query.minPrice as string) : undefined,
+      maxPrice: req.query.maxPrice ? parseFloat(req.query.maxPrice as string) : undefined,
+      minRooms: req.query.minRooms ? parseInt(req.query.minRooms as string) : undefined,
+      maxRooms: req.query.maxRooms ? parseInt(req.query.maxRooms as string) : undefined,
+      minBathrooms: req.query.minBathrooms ? parseInt(req.query.minBathrooms as string) : undefined,
+      maxBathrooms: req.query.maxBathrooms ? parseInt(req.query.maxBathrooms as string) : undefined
+    };
 
-    const where = available ? { available: available === 'true' } : {};
-
-    const housing = await prisma.housing.findMany({
-      where,
-      include: {
-        owner: {
-          select: {
-            id: true,
-            name: true,
-            email: true
-          }
-        }
-      },
-      orderBy: {
-        createdAt: 'desc'
-      }
-    });
+    const housing = await housingService.filterHousing(filters);
 
     res.status(200).json({ housing });
   } catch (error) {

--- a/src/services/housingService.ts
+++ b/src/services/housingService.ts
@@ -10,6 +10,7 @@ interface HousingFilter {
     maxRooms?: number;
     minBathrooms?: number;
     maxBathrooms?: number;
+    address?: string
 }
 
 export const filterHousing = async (filters: HousingFilter) => {
@@ -20,7 +21,8 @@ export const filterHousing = async (filters: HousingFilter) => {
         minRooms,
         maxRooms,
         minBathrooms,
-        maxBathrooms
+        maxBathrooms,
+        address
     } = filters;
 
     const where: any = {};
@@ -48,6 +50,13 @@ export const filterHousing = async (filters: HousingFilter) => {
         ...(minBathrooms && { gte: minBathrooms }),
         ...(maxBathrooms && { lte: maxBathrooms }),
       };
+    }
+
+    if (address) {
+        where.address = {
+            contains: address,
+            mode: 'insensitive'
+        };
     }
 
     return prisma.housing.findMany({

--- a/src/services/housingService.ts
+++ b/src/services/housingService.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '../prisma';
 
 interface HousingFilter {
     available: boolean;

--- a/src/services/housingService.ts
+++ b/src/services/housingService.ts
@@ -1,0 +1,72 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+interface HousingFilter {
+    available: boolean;
+    minPrice?: number;
+    maxPrice?: number;
+    minRooms?: number;
+    maxRooms?: number;
+    minBathrooms?: number;
+    maxBathrooms?: number;
+}
+
+export const filterHousing = async (filters: HousingFilter) => {
+    const {
+        available,
+        minPrice,
+        maxPrice,
+        minRooms,
+        maxRooms,
+        minBathrooms,
+        maxBathrooms
+    } = filters;
+
+    const where: any = {};
+
+    if (available !== undefined) {
+      where.available = available;
+    }
+
+    if (minPrice || maxPrice) {
+      where.price = {
+        ...(minPrice && { gte: minPrice }),
+        ...(maxPrice && { lte: maxPrice }),
+      };
+    }
+
+    if (minRooms || maxRooms) {
+      where.rooms = {
+        ...(minRooms && { gte: minRooms }),
+        ...(maxRooms && { lte: maxRooms }),
+      };
+    }
+
+    if (minBathrooms || maxBathrooms) {
+      where.bathrooms = {
+        ...(minBathrooms && { gte: minBathrooms }),
+        ...(maxBathrooms && { lte: maxBathrooms }),
+      };
+    }
+
+    return prisma.housing.findMany({
+      where,
+      include: {
+        owner: {
+          select: {
+            id: true,
+            name: true,
+            email: true
+          }
+        }
+      },
+      orderBy: {
+        createdAt: 'desc'
+      }
+    });
+};
+
+export default {
+    filterHousing,
+};


### PR DESCRIPTION
## 📌 Descripción

Se habilitan filtros para búsqueda de las propiedades, incluyendo un filtro por ubicación (_address_) de forma que se pueda filtrar por Región Metropolitana. Asimismo, se separó la lógica del controlador con capa de servicios, de forma que 

## ✅ Cambios realizados

- [X] Modificación de endpoint para listar propiedades, añadiendo filtros
- [X] Creación de _service layer_ para validar la lógica de la búsqueda

## 🧪 Cómo probar los cambios

<!-- Describe los pasos para revisar/testear los cambios manualmente -->

N/A
