### PR TITLE
fix: modified maximum file size from 1MB to 20MB

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: '20mb' }));
 
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 


### PR DESCRIPTION
## 📌 Descripción

Esta PR modifica el tamaño máximo de los archivos de 1MB a 20MB. Esto evita errores en imágenes de tamaño mediano, las cuales no pueden ser subidas hasta antes de este arreglo.

## ✅ Cambios realizados

- [X] Corrección de bug en tamaño máximo de archivos

## 🧪 Cómo probar los cambios

1. `cd backend && npm run dev`
2. `cd frontend && npm run dev`
3. Ir a `http://localhost:5173/`
4. Iniciar sesión
5. Crear una propiedad y adjuntar una imagen de más de 1MB y menos de 20MB.
