### PR TITLE
feat: recent housing endpoint

### DIFF
--- a/src/__tests__/housingController.test.ts
+++ b/src/__tests__/housingController.test.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { prismaMock } from '../singleton';
-import { createHousing, getHousing, updateHousing, deleteHousing, listHousing } from '../controllers/housingController';
+import { createHousing, getHousing, updateHousing, deleteHousing, listHousing, isRecentHousing } from '../controllers/housingController';
 
 
 test('should create a new housing if user is propietario', async () => {
@@ -100,5 +100,103 @@ test('should return error if user is not propietario', async () => {
   expect(mockResponse.status).toHaveBeenCalledWith(400);
   expect(mockResponse.json).toHaveBeenCalledWith({
     message: 'Invalid owner',
+  });
+});
+
+test('should return true if housing was created in the past half hour', async () => {
+  // Current time for the test
+  const now = new Date();
+  // Housing created 15 minutes ago
+  const createdAt = new Date(now.getTime() - 15 * 60 * 1000);
+
+  const req = {
+    params: { id: '1' }
+  } as unknown as Request;
+
+  const mockResponse = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as unknown as Response;
+
+  prismaMock.housing.findUnique.mockResolvedValue({
+    id: 1,
+    title: 'Test Housing',
+    description: 'Test Description',
+    address: 'Test Address',
+    price: 1000,
+    rooms: 2,
+    bathrooms: 1,
+    size: 100,
+    images: ['test.jpg'],
+    ownerId: 1,
+    available: true,
+    createdAt: createdAt,
+    updatedAt: createdAt,
+  });
+
+  await isRecentHousing(req, mockResponse);
+
+  expect(mockResponse.status).toHaveBeenCalledWith(200);
+  expect(mockResponse.json).toHaveBeenCalledWith({
+    isRecent: true
+  });
+});
+
+test('should return false if housing was created more than half hour ago', async () => {
+  // Current time for the test
+  const now = new Date();
+  // Housing created 45 minutes ago
+  const createdAt = new Date(now.getTime() - 45 * 60 * 1000);
+
+  const req = {
+    params: { id: '1' }
+  } as unknown as Request;
+
+  const mockResponse = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as unknown as Response;
+
+  prismaMock.housing.findUnique.mockResolvedValue({
+    id: 1,
+    title: 'Test Housing',
+    description: 'Test Description',
+    address: 'Test Address',
+    price: 1000,
+    rooms: 2,
+    bathrooms: 1,
+    size: 100,
+    images: ['test.jpg'],
+    ownerId: 1,
+    available: true,
+    createdAt: createdAt,
+    updatedAt: createdAt,
+  });
+
+  await isRecentHousing(req, mockResponse);
+
+  expect(mockResponse.status).toHaveBeenCalledWith(200);
+  expect(mockResponse.json).toHaveBeenCalledWith({
+    isRecent: false
+  });
+});
+
+test('should return 404 if housing not found when checking if recent', async () => {
+  const req = {
+    params: { id: '999' }
+  } as unknown as Request;
+
+  const mockResponse = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as unknown as Response;
+
+  prismaMock.housing.findUnique.mockResolvedValue(null);
+
+  await isRecentHousing(req, mockResponse);
+
+  expect(mockResponse.status).toHaveBeenCalledWith(404);
+  expect(mockResponse.json).toHaveBeenCalledWith({
+    message: 'Housing not found'
   });
 });

--- a/src/controllers/housingController.ts
+++ b/src/controllers/housingController.ts
@@ -160,3 +160,29 @@ export const listHousing = async (req: Request, res: Response) => {
     res.status(500).json({ message: 'Error listing housing' });
   }
 };
+
+export const isRecentHousing = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    
+    const housing = await prisma.housing.findUnique({
+      where: { id: parseInt(id) }
+    });
+
+    if (!housing) {
+      return res.status(404).json({ message: 'Housing not found' });
+    }
+
+    // Calculate if the housing was created within the last 30 minutes
+    const now = new Date();
+    const createdAt = new Date(housing.createdAt);
+    const thirtyMinutesAgo = new Date(now.getTime() - 30 * 60 * 1000);
+    
+    const isRecent = createdAt >= thirtyMinutesAgo;
+
+    res.status(200).json({ isRecent });
+  } catch (error) {
+    console.error('Error checking if housing is recent:', error);
+    res.status(500).json({ message: 'Error checking if housing is recent' });
+  }
+};

--- a/src/routes/housingRoutes.ts
+++ b/src/routes/housingRoutes.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { createHousing, getHousing, updateHousing, deleteHousing, listHousing } from '../controllers/housingController';
+import { createHousing, getHousing, updateHousing, deleteHousing, listHousing, isRecentHousing } from '../controllers/housingController';
 
 const router = Router();
 
@@ -192,5 +192,38 @@ router.delete('/:id', async (req: Request, res: Response) => {
  *         description: Server error
  */
 router.get('/', listHousing);
+
+/**
+ * @swagger
+ * /api/housing/{id}/recent:
+ *   get:
+ *     summary: Check if housing was created in the past half hour
+ *     tags: [Housing]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID of the housing to check
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 isRecent:
+ *                   type: boolean
+ *                   description: Whether the housing was created in the past 30 minutes
+ *       404:
+ *         description: Housing not found
+ *       500:
+ *         description: Server error
+ */
+router.get('/:id/recent', async (req: Request, res: Response) => {
+  await isRecentHousing(req, res);
+});
 
 export default router;


### PR DESCRIPTION
## 📌 Descripción

Nuevo endpoint para saber si una propiedad fue creada recientemente para errores más descriptivos en el frontend

## ✅ Cambios realizados

- [x] Nuevo endpoint para saber si una propiedad fue creada recientemente
- [ ] Actualización de modelo Prisma: ...
- [ ] Corrección de bug en ...
- [ ] Agregado test para ...
- [ ] Estilos/UX en componente ...

## 🧪 Cómo probar los cambios

1. `cd backend && npm run dev`
2. `cd frontend && npm run dev`
3. Ir a `http://localhost:3000/housing/new`
4. Intetar apretar 2 veces el boton para crear una propiedad con los mismos datos
