### PR TITLE
Fix housing review dependance when deleting housing

### DIFF
--- a/src/controllers/housingController.ts
+++ b/src/controllers/housingController.ts
@@ -152,6 +152,10 @@ export const deleteHousing = async (req: Request, res: Response) => {
       return res.status(403).json({ message: 'Not authorized' });
     }
 
+    await prisma.review.deleteMany({
+      where: { housingId: parseInt(id) }
+    });
+
     await prisma.housing.delete({
       where: { id: parseInt(id) }
     });


### PR DESCRIPTION
## 📌 Descripción

Se eliminan todas las reseñas de una propiedad antes de borrar propiedad

## ✅ Cambios realizados

- [ ] Nuevo endpoint para ...
- [ ] Actualización de modelo Prisma: ...
- [x] Corrección de bug en housing controller
- [ ] Agregado test para ...
- [ ] Estilos/UX en componente ...

## 🧪 Cómo probar los cambios

1. `cd backend && npm run dev`
2. `cd frontend && npm run dev`
3. Ir a mis propiedades y apretar editar en una
4. Apretar eliminar propiedad y verificar que se elimine correctamente
